### PR TITLE
Add support for SageTV server to signal Subtitle track changes

### DIFF
--- a/android-shared/src/main/java/sagex/miniclient/android/video/exoplayer2/Exo2MediaPlayerImpl.java
+++ b/android-shared/src/main/java/sagex/miniclient/android/video/exoplayer2/Exo2MediaPlayerImpl.java
@@ -55,7 +55,6 @@ public class Exo2MediaPlayerImpl extends BaseMediaPlayerImpl<SimpleExoPlayer, Da
     long resumePos = -1;
     long logLastTime = -1;
     int initialAudioTrackIndex = -1;
-    int initialAudioTrackType = -1;
 
     DefaultTrackSelector trackSelector;
 
@@ -203,18 +202,22 @@ public class Exo2MediaPlayerImpl extends BaseMediaPlayerImpl<SimpleExoPlayer, Da
     }
 
     @Override
-    public void setAudioTrack(int streamType, int streamPos)
+    public void setSubtitleTrack(int streamPos)
+    {
+
+    }
+
+    @Override
+    public void setAudioTrack(int streamPos)
     {
 
         if(!ExoIsPlaying())
         {
             initialAudioTrackIndex = streamPos;
-            initialAudioTrackType = streamType;
         }
         else
         {
             initialAudioTrackIndex = -1;
-            initialAudioTrackType = -1;
             changeTrack(C.TRACK_TYPE_AUDIO, streamPos, 0);
         }
     }
@@ -306,7 +309,7 @@ public class Exo2MediaPlayerImpl extends BaseMediaPlayerImpl<SimpleExoPlayer, Da
 
                     if(initialAudioTrackIndex != -1)
                     {
-                        setAudioTrack(0, initialAudioTrackIndex);
+                        setAudioTrack(initialAudioTrackIndex);
                     }
                 }
             }

--- a/core/src/main/java/sagex/miniclient/MediaCmd.java
+++ b/core/src/main/java/sagex/miniclient/MediaCmd.java
@@ -57,6 +57,10 @@ public class MediaCmd {
 
     public static final int MEDIACMD_DVD_STREAMS = 36;
 
+
+    public static final int STREAM_TYPE_AUDIO = 0;
+    public static final int STREAM_TYPE_SUBTITLE = 1;
+
     public static final Map<Integer, String> CMDMAP = new HashMap<Integer, String>();
     private static final Logger log = LoggerFactory.getLogger(MediaCmd.class);
 
@@ -394,10 +398,17 @@ public class MediaCmd {
                 int streamType = readInt(0, cmddata);
                 int streamPos = readInt(4, cmddata);
 
-                log.debug("JVL ---------------------- [MEDIACMD_DVD_STREAMS] ---------------------- ");
                 log.debug("Stream Type: {}  Stream Pos: {}", streamType, streamPos);
 
-                playa.setAudioTrack(streamType, streamPos);
+                if(streamType == STREAM_TYPE_AUDIO)
+                {
+                    playa.setAudioTrack(streamPos);
+                }
+                else if(streamType == STREAM_TYPE_SUBTITLE)
+                {
+                    playa.setSubtitleTrack(streamPos);
+                }
+
 
                 writeInt(0, retbuf, 0);
 

--- a/core/src/main/java/sagex/miniclient/MiniPlayerPlugin.java
+++ b/core/src/main/java/sagex/miniclient/MiniPlayerPlugin.java
@@ -100,10 +100,15 @@ public interface MiniPlayerPlugin extends Runnable {
 
     /**
      * Set the audio track to be played back.
-     * @param streamType The type of audio stream.
      * @param streamPos The audio track position (zero based) in the file
      */
-    void setAudioTrack(int streamType, int streamPos);
+    void setAudioTrack(int streamPos);
+
+    /**
+     * Set the subtitle track to be played back.
+     * @param streamPos The audio track position (zero based) in the file
+     */
+    void setSubtitleTrack(int streamPos);
 
     void setVideoRectangles(Rectangle srcRect, Rectangle destRect, boolean hideCursor);
 


### PR DESCRIPTION
I dd not realize when I made the changes for audio track change that the same command was also used for subtitle changes.  Stream Type = 0 is for audio and Stream Type = 1 is for subtitle.  I added the code to tell IJK and Exo players to switch tracks, but I did not implement.  I am not sure if IJK supports and subtitles.  Exo may support them, but I have not looked into implementing yet.